### PR TITLE
Add 4.3 plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,10 @@
+# .github/workflows/ci.yml
+name: ci
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    uses: catalyst/catalyst-moodle-workflows/.github/workflows/ci.yml@main
+    with:
+      disable_phpunit: true # Currently there are no tests, enabling this causes an error.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# Login banner MFA factor
+This is a Moodle plugin which adds a MFA factor to display a login banner.
+
+Originally included in Catalyst's tool_mfa plugin, it has now been split off into its own repository as tool_mfa was added to Moodle core in 4.3 as part of https://tracker.moodle.org/browse/MDL-78509.
+
+It was taken at this commit: https://github.com/catalyst/moodle-tool_mfa/tree/7fed04b24c3857e155fb2b29b70e04d6f2d42aff/factor/loginbanner
+
+# How does it work
+
+This factor allows for display of a policy which forces users to read and accept a policy on every login. This is more flexible than the Moodle policy tool, which is built for one time acceptance. To set the message, a custom language pack should be used to override factor_loginbanner/policytext. This means that it can be replaced with an arbitrary set of HTML to display to the users. This factor should be used with a weight of 0 if you wish it to be an additional layer over the top of the MFA flow, without contributing any weight.
+
+
+# Branches
+
+| Branch            | Version     |
+|-------------------|-------------|
+| MOODLE_403_STABLE | Moodle 4.3+ |
+
+# Contributing and support
+
+Issues, and pull requests using github are welcome and encouraged!
+
+https://github.com/catalyst/moodle-factor_loginbanner/issues
+
+If you would like commercial support or would like to sponsor additional improvements to this plugin please contact us:
+
+https://www.catalyst-au.net/contact-us

--- a/classes/factor.php
+++ b/classes/factor.php
@@ -35,8 +35,25 @@ class factor extends object_factor_base {
      * @param stdClass $user the user to check against.
      * @return array
      */
-    public function get_all_user_factors($user) {
-        return $this->get_singleton_user_factor($user);
+    public function get_all_user_factors(\stdClass $user): array {
+        global $DB;
+        $records = $DB->get_records('tool_mfa', ['userid' => $user->id, 'factor' => $this->name]);
+
+        if (!empty($records)) {
+            return $records;
+        }
+
+        // Null records returned, build new record.
+        $record = [
+            'userid' => $user->id,
+            'factor' => $this->name,
+            'timecreated' => time(),
+            'createdfromip' => $user->lastip,
+            'timemodified' => time(),
+            'revoked' => 0,
+        ];
+        $record['id'] = $DB->insert_record('tool_mfa', $record, true);
+        return [(object) $record];
     }
 
     /**
@@ -44,7 +61,7 @@ class factor extends object_factor_base {
      *
      * {@inheritDoc}
      */
-    public function has_input() {
+    public function has_input(): bool {
         return true;
     }
 
@@ -54,7 +71,7 @@ class factor extends object_factor_base {
      * @param \MoodleQuickForm $mform
      * @return object $mform
      */
-    public function login_form_definition($mform) {
+    public function login_form_definition(\MoodleQuickForm $mform): \MoodleQuickForm {
         $mform->addElement('html', get_string('policytext', 'factor_loginbanner'));
         return $mform;
     }
@@ -66,7 +83,7 @@ class factor extends object_factor_base {
      *
      * {@inheritDoc}
      */
-    public function process_cancel_action() {
+    public function process_cancel_action(): void {
         global $CFG;
 
         $this->set_state(\tool_mfa\plugininfo\factor::STATE_FAIL);
@@ -79,7 +96,7 @@ class factor extends object_factor_base {
      *
      * @param \stdClass $user
      */
-    public function possible_states($user) {
+    public function possible_states(\stdClass $user): array {
         // Policy can only return a pass or fail when known.
         return [
             \tool_mfa\plugininfo\factor::STATE_FAIL,

--- a/classes/factor.php
+++ b/classes/factor.php
@@ -1,0 +1,90 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace factor_loginbanner;
+
+use tool_mfa\local\factor\object_factor_base;
+
+/**
+ * Policy factor class.
+ *
+ * @package     factor_loginbanner
+ * @author      Peter Burnett <peterburnett@catalyst-au.net>
+ * @copyright   Catalyst IT
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class factor extends object_factor_base {
+
+    /**
+     * Login banner Factor implementation.
+     * Factor is a singleton, can only be one instance.
+     *
+     * @param stdClass $user the user to check against.
+     * @return array
+     */
+    public function get_all_user_factors($user) {
+        return $this->get_singleton_user_factor($user);
+    }
+
+    /**
+     * Login banner factor implementation.
+     *
+     * {@inheritDoc}
+     */
+    public function has_input() {
+        return true;
+    }
+
+    /**
+     * Login banner factor implementation.
+     *
+     * @param \MoodleQuickForm $mform
+     * @return object $mform
+     */
+    public function login_form_definition($mform) {
+        $mform->addElement('html', get_string('policytext', 'factor_loginbanner'));
+        return $mform;
+    }
+
+    /**
+     * Login banner Factor implementation.
+     * A cancel action is a decline for this factor.
+     * This should result in an instant fail and unable to auth.
+     *
+     * {@inheritDoc}
+     */
+    public function process_cancel_action() {
+        global $CFG;
+
+        $this->set_state(\tool_mfa\plugininfo\factor::STATE_FAIL);
+        \tool_mfa\manager::mfa_logout();
+        redirect($CFG->wwwroot);
+    }
+
+    /**
+     * Login banner factor implementation.
+     *
+     * @param \stdClass $user
+     */
+    public function possible_states($user) {
+        // Policy can only return a pass or fail when known.
+        return [
+            \tool_mfa\plugininfo\factor::STATE_FAIL,
+            \tool_mfa\plugininfo\factor::STATE_PASS,
+            \tool_mfa\plugininfo\factor::STATE_UNKNOWN,
+        ];
+    }
+}

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -1,0 +1,42 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace factor_loginbanner\privacy;
+
+use core_privacy\local\metadata\null_provider;
+use core_privacy\local\legacy_polyfill;
+
+/**
+ * Privacy provider.
+ *
+ * @package     factor_loginbanner
+ * @author      Peter Burnett <peterburnett@catalyst-au.net>
+ * @copyright   Catalyst IT
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class provider implements null_provider {
+    use legacy_polyfill;
+
+    /**
+     * Get the language string identifier with the component's language
+     * file to explain why this plugin stores no data.
+     *
+     * @return  string
+     */
+    public static function _get_reason() {
+        return 'privacy:metadata';
+    }
+}

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -28,15 +28,13 @@ use core_privacy\local\legacy_polyfill;
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class provider implements null_provider {
-    use legacy_polyfill;
-
     /**
      * Get the language string identifier with the component's language
      * file to explain why this plugin stores no data.
      *
      * @return  string
      */
-    public static function _get_reason() {
+    public static function get_reason(): string {
         return 'privacy:metadata';
     }
 }

--- a/lang/en/factor_loginbanner.php
+++ b/lang/en/factor_loginbanner.php
@@ -1,0 +1,32 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Language strings.
+ *
+ * @package     factor_loginbanner
+ * @author      Peter Burnett <peterburnett@catalyst-au.net>
+ * @copyright   Catalyst IT
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+$string['info'] = 'This factor forces users to read and accept a policy, otherwise they will be unable to authenticate to the system';
+$string['loginskip'] = 'Decline and log out';
+$string['loginsubmit'] = 'Accept';
+$string['pluginname'] = 'Login banner';
+$string['policytext'] = '<p>This is a placeholder policy text. This can be overridden in the sites language pack configuration menu.</p>';
+$string['privacy:metadata'] = 'The Policy factor plugin does not store any personal data';
+$string['summarycondition'] = 'accepts the user policy';

--- a/lang/en/factor_loginbanner.php
+++ b/lang/en/factor_loginbanner.php
@@ -25,8 +25,11 @@
 
 $string['info'] = 'This factor forces users to read and accept a policy, otherwise they will be unable to authenticate to the system';
 $string['loginskip'] = 'Decline and log out';
+$string['loginoption'] = 'Accept login banner';
 $string['loginsubmit'] = 'Accept';
 $string['pluginname'] = 'Login banner';
 $string['policytext'] = '<p>This is a placeholder policy text. This can be overridden in the sites language pack configuration menu.</p>';
 $string['privacy:metadata'] = 'The Policy factor plugin does not store any personal data';
 $string['summarycondition'] = 'accepts the user policy';
+$string['logintitle'] = 'Accept user policy';
+$string['logindesc'] = '';

--- a/settings.php
+++ b/settings.php
@@ -1,0 +1,38 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Loginbanner factor Settings.
+ *
+ * @package     factor_loginbanner
+ * @author      Peter Burnett <peterburnett@catalyst-au.net>
+ * @copyright   Catalyst IT
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+$enabled = new admin_setting_configcheckbox('factor_loginbanner/enabled',
+    new lang_string('settings:enablefactor', 'tool_mfa'),
+    new lang_string('settings:enablefactor_help', 'tool_mfa'), 0);
+$enabled->set_updatedcallback(function () {
+    \tool_mfa\manager::do_factor_action('loginbanner', get_config('factor_loginbanner', 'enabled') ? 'enable' : 'disable');
+});
+$settings->add($enabled);
+
+$settings->add(new admin_setting_configtext('factor_loginbanner/weight',
+    new lang_string('settings:weight', 'tool_mfa'),
+    new lang_string('settings:weight_help', 'tool_mfa'), 100, PARAM_INT));

--- a/version.php
+++ b/version.php
@@ -1,0 +1,34 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Plugin version and other meta-data are defined here.
+ *
+ * @package     factor_loginbanner
+ * @subpackage  tool_mfa
+ * @author      Peter Burnett <peterburnett@catalyst-au.net>
+ * @copyright   Catalyst IT
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+$plugin->version      = 2021030800;      // The current plugin version (Date: YYYYMMDDXX).
+$plugin->release      = 2021030800;      // Keep in lockstep with version.
+$plugin->requires     = 2022041908; // Support Moodle 4.0 and higher.
+$plugin->component    = 'factor_loginbanner';
+$plugin->maturity     = MATURITY_STABLE;
+$plugin->dependencies = ['tool_mfa' => 2019102400];

--- a/version.php
+++ b/version.php
@@ -26,9 +26,10 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version      = 2021030800;      // The current plugin version (Date: YYYYMMDDXX).
-$plugin->release      = 2021030800;      // Keep in lockstep with version.
-$plugin->requires     = 2022041908; // Support Moodle 4.0 and higher.
+$plugin->version      = 2025051900;
+$plugin->release      = 2025051900;
+$plugin->requires     = 2023100900; // Moodle 4.3.0
 $plugin->component    = 'factor_loginbanner';
 $plugin->maturity     = MATURITY_STABLE;
-$plugin->dependencies = ['tool_mfa' => 2019102400];
+$plugin->dependencies = ['tool_mfa' => 2023031600]; // tool_mfa at time of core MDL-78509 import
+$plugin->supported    = [403, 500];

--- a/version.php
+++ b/version.php
@@ -28,8 +28,8 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->version      = 2025051900;
 $plugin->release      = 2025051900;
-$plugin->requires     = 2023100900; // Moodle 4.3.0
+$plugin->requires     = 2023100900; // Moodle 4.3.0.
 $plugin->component    = 'factor_loginbanner';
 $plugin->maturity     = MATURITY_STABLE;
-$plugin->dependencies = ['tool_mfa' => 2023031600]; // tool_mfa at time of core MDL-78509 import
+$plugin->dependencies = ['tool_mfa' => 2023031600]; // Version of tool_mfa at time of core MDL-78509 import.
 $plugin->supported    = [403, 500];


### PR DESCRIPTION
**Background info**
tool_mfa is core in 4.3+, but they have chosen not to include the login banner factor. Thus, i've split it off into its own repo, so 4.3+ sites can continue to use this factor.

**Changes**
- Ported over code from `tool_mfa`
- Updated readme
- Updated `version.php` to be 4.3+
- Add github ci
- Fixup type hinting to match core
- Fixups due to slight API/function differences in core vs plugin version

**Testing**
- Tested manually adding banner with 100 weight, log out, log in, and confirm banner is shown